### PR TITLE
Minor tweaks and cleanups (details are in commit messages).

### DIFF
--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -208,13 +208,8 @@ class ConfDialog(QDialog):
 
     def saveconf(self, s):
         global addrbox, ifacebox, status
-        addr = self.addrbox.toPlainText()
-        iface = self.ifacebox.toPlainText()
-
-        if addr == '':
-            addr = '0x00008000'
-        if iface == '':
-            iface = 'stlink.cfg'
+        addr = self.addrbox.toPlainText() or '0x00008000'
+        iface = self.ifacebox.toPlainText() or 'stlink.cfg'
 
         if int(addr, 0) <= 479232 and int(addr, 0) >= 0:
             try:

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -219,7 +219,7 @@ class ConfDialog(QDialog):
             except OSError:
                 self.status.setText('Unable to write configuration file!')
         else:
-            self.status.setText('Flash address is out of range!')
+            self.status.setText('Flash address not in the valid range (0x0 - 0x00075000)')
 
     def infoButton(self, s):
         dlg = InfoDialog()

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -3,7 +3,7 @@
 import sys
 import os
 import shutil
-import subprocess
+from pathlib import Path
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
@@ -24,20 +24,6 @@ def progress_parser(output):
         return 100
     else:
         return None
-
-
-# Source: https://stackoverflow.com/a/48706260/4914192
-def get_download_path():
-    """Returns the default downloads path for linux or windows"""
-    if os.name == 'nt':
-        import winreg
-        sub_key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
-        downloads_guid = '{374DE290-123F-4565-9164-39C4925E467B}'
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, sub_key) as key:
-            location = winreg.QueryValueEx(key, downloads_guid)[0]
-        return location
-    else:
-        return os.path.join(os.path.expanduser('~'), 'downloads')
 
 
 # Main Program Class and UI
@@ -152,10 +138,8 @@ class ptflasher(QMainWindow):
     def filesearch(self):
         global progress, filedir
 
-        downloadsFolder = get_download_path()
-
         datafile = self.filedialog.getOpenFileName(caption="Select firmware file to flash...",
-                                                   directory=downloadsFolder,
+                                                   directory=str(Path.home() / "Downloads"),
                                                    filter="PineTime Firmware (*.bin *.hex)")
 
         if datafile[0] != "":

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -85,7 +85,7 @@ class ptflasher(QMainWindow):
                     data = pickle.load(f)
                     default_addr = data[0]
                     default_iface = data[1]
-            except:
+            except OSError:
                 default_addr = "0x00008000"
                 default_iface = "stlink.cfg"
 
@@ -197,8 +197,7 @@ class ConfDialog(QDialog):
                 default_iface = data[1]
                 self.addrbox.setText(default_addr)
                 self.ifacebox.setText(default_iface)
-
-        except:
+        except OSError:
             self.addrbox.setText(default_addr)
             self.ifacebox.setText(default_iface)
 
@@ -219,10 +218,12 @@ class ConfDialog(QDialog):
                 iface = 'stlink.cfg'
 
         if int(addr, 0) <= 479232 and int(addr, 0) >= 0:
-            with open('conf.dat', 'wb+') as f:
-                pickle.dump((addr, iface), f)
-            self.status.setText('Configuration Saved.')
-
+            try:
+                with open('conf.dat', 'wb+') as f:
+                    pickle.dump((addr, iface), f)
+                self.status.setText('Configuration Saved.')
+            except OSError:
+                self.status.setText('Unable to write configuration file!')
         else:
             self.status.setText('Flash address is out of range!')
 

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -119,7 +119,7 @@ class ptflasher(QMainWindow):
             self.progress.setValue(0)
 
     def flash_finished(self, ):
-        if (self.p.exitCode() == 0):
+        if self.p.exitCode() == 0:
             self.status.setText('Success!')
         else:
             self.status.setText('Something probably went wrong :(')

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -211,7 +211,7 @@ class ConfDialog(QDialog):
         addr = self.addrbox.toPlainText() or '0x00008000'
         iface = self.ifacebox.toPlainText() or 'stlink.cfg'
 
-        if int(addr, 0) <= 479232 and int(addr, 0) >= 0:
+        if int(addr, 0) <= 0x00075000 and int(addr, 0) >= 0:
             try:
                 with open('conf.dat', 'wb+') as f:
                     pickle.dump((addr, iface), f)

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -211,11 +211,10 @@ class ConfDialog(QDialog):
         addr = self.addrbox.toPlainText()
         iface = self.ifacebox.toPlainText()
 
-        if addr == '' or iface == '':
-            if addr == '':
-                addr = '0x00008000'
-            if iface == '':
-                iface = 'stlink.cfg'
+        if addr == '':
+            addr = '0x00008000'
+        if iface == '':
+            iface = 'stlink.cfg'
 
         if int(addr, 0) <= 479232 and int(addr, 0) >= 0:
             try:


### PR DESCRIPTION
Using str(Path.home() / "Downloads") avoids needing to query the registry and means the get_download_path() can be removed entirely. It also makes in a bit easier to read.

In addition, the directory name also starts with a capital 'D' on Ubuntu.