### PR TITLE
Download and add openocd to the system path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,8 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# OpenOCD files and directories
+openocd/
+openocd_tmp/
+openocd-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Program config file
 conf.dat
 
-# VSCode workspace settings
+# IDE workspace settings
 .vscode/
+.idea/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -74,7 +74,7 @@ class ptflasher(QMainWindow):
         self.searchbtn = QPushButton("Search for file")
         self.confbtn = QPushButton("Configure flashing options...")
         self.infobtn = QPushButton("More info")
-        self.status = QLabel("Ready.")
+        self.status = QLabel("")
 
         self.flashbtn.clicked.connect(self.startflash)
         self.searchbtn.clicked.connect(self.filesearch)
@@ -177,6 +177,7 @@ class ptflasher(QMainWindow):
     def confButton(self, s):
         dlg = ConfDialog()
         dlg.exec()
+        self.update_control_statuses()
 
     def info_button(self):
         dlg = InfoDialog()

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -52,7 +52,6 @@ class ptflasher(QMainWindow):
         self.resize(300, 200)
 
         self.info = QLabel("Enter the path of the file to be flashed")
-
         self.filedir = QPlainTextEdit()
 
         self.progress = QProgressBar()
@@ -64,22 +63,24 @@ class ptflasher(QMainWindow):
         self.flashbtn = QPushButton("Start flashing")
         self.searchbtn = QPushButton("Search for file")
         self.confbtn = QPushButton("Configure flashing options...")
+        self.infobtn = QPushButton("More info")
+        self.status = QLabel("Ready.")
+
         self.flashbtn.clicked.connect(self.startflash)
         self.searchbtn.clicked.connect(self.filesearch)
         self.confbtn.clicked.connect(self.confButton)
         self.filedir.textChanged.connect(self.update_control_statuses)
+        self.infobtn.clicked.connect(self.info_button)
         self.flashbtn.setEnabled(False)
 
-        self.status = QLabel("Ready.")
-
         layout = QVBoxLayout()
-
         layout.addWidget(self.info)
         layout.addWidget(self.filedir)
         layout.addWidget(self.progress)
         layout.addWidget(self.searchbtn)
         layout.addWidget(self.flashbtn)
         layout.addWidget(self.confbtn)
+        layout.addWidget(self.infobtn)
         layout.addWidget(self.status)
 
         w = QWidget()
@@ -167,6 +168,10 @@ class ptflasher(QMainWindow):
         dlg = ConfDialog()
         dlg.exec()
 
+    def info_button(self):
+        dlg = InfoDialog()
+        dlg.exec()
+
 
 # Configuration class and UI
 class ConfDialog(QDialog):
@@ -190,7 +195,6 @@ class ConfDialog(QDialog):
         self.ifacebox = QPlainTextEdit()
 
         self.savebtn = QPushButton("Save configuration")
-        self.infobtn = QPushButton("More info")
 
         self.status = QLabel("")
 
@@ -201,11 +205,7 @@ class ConfDialog(QDialog):
         conflayout.addWidget(self.addrbox)
         conflayout.addWidget(self.ifaceinfo)
         conflayout.addWidget(self.ifacebox)
-
-        confbuttonrow.addWidget(self.savebtn)
-        confbuttonrow.addWidget(self.infobtn)
-
-        conflayout.addLayout(confbuttonrow)
+        conflayout.addWidget(self.savebtn)
         conflayout.addWidget(self.status)
 
         self.setLayout(conflayout)
@@ -214,7 +214,6 @@ class ConfDialog(QDialog):
         self.addrbox.setCurrentIndex(self.get_firmware_index(address))
         self.ifacebox.setPlainText(interface)
 
-        self.infobtn.clicked.connect(self.infoButton)
         self.savebtn.clicked.connect(self.saveconf)
 
         self.setWindowModality(Qt.ApplicationModal)
@@ -235,10 +234,6 @@ class ConfDialog(QDialog):
             self.status.setText("Configuration Saved.")
         except OSError:
             self.status.setText("Unable to write configuration file!")
-
-    def infoButton(self, s):
-        dlg = InfoDialog()
-        dlg.exec()
 
 
 # Info screen class and UI

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
-
+import hashlib
+import platform
 import sys
 import os
 import shutil
+import requests
+import json
+import wget
 from pathlib import Path
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
 import pickle
+from typing import List
+
+
+def add_openocd_to_system_path(status_notice: QLabel):
+    openocd_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'openocd', 'bin')
+    os.environ["PATH"] = os.environ["PATH"] + os.pathsep + openocd_path
+    status_notice.setText("OpenOCD downloaded and added to system path.")
 
 
 # Returns percentage progress value in response to key phrases from OpenOCD
@@ -87,6 +98,8 @@ class ptflasher(QMainWindow):
         w.setLayout(layout)
 
         self.setCentralWidget(w)
+        if os.path.exists('openocd'):
+            add_openocd_to_system_path(self.status)
 
     def update_control_statuses(self):
         def enable_buttons(enable: bool, reason: str):
@@ -184,7 +197,7 @@ class ConfDialog(QDialog):
         ]
 
         self.setWindowTitle("Flash Configuration")
-        self.resize(300, 200)
+        self.resize(300, 220)
 
         self.addrinfo = QLabel("Firmware type (used to determine address):")
         self.addrbox = QComboBox()
@@ -195,7 +208,7 @@ class ConfDialog(QDialog):
         self.ifacebox = QPlainTextEdit()
 
         self.savebtn = QPushButton("Save configuration")
-
+        self.openocd_btn = QPushButton("Download OpenOCD")
         self.status = QLabel("")
 
         conflayout = QVBoxLayout()
@@ -206,6 +219,7 @@ class ConfDialog(QDialog):
         conflayout.addWidget(self.ifaceinfo)
         conflayout.addWidget(self.ifacebox)
         conflayout.addWidget(self.savebtn)
+        conflayout.addWidget(self.openocd_btn)
         conflayout.addWidget(self.status)
 
         self.setLayout(conflayout)
@@ -215,6 +229,7 @@ class ConfDialog(QDialog):
         self.ifacebox.setPlainText(interface)
 
         self.savebtn.clicked.connect(self.saveconf)
+        self.openocd_btn.clicked.connect(self.setup_openocd)
 
         self.setWindowModality(Qt.ApplicationModal)
 
@@ -234,6 +249,83 @@ class ConfDialog(QDialog):
             self.status.setText("Configuration Saved.")
         except OSError:
             self.status.setText("Unable to write configuration file!")
+
+    def setup_openocd(self):
+        """
+        Download and unpack OpenOCD for the current platform, then add it to the system path.
+        """
+        self.status.setText("Finding latest OpenOCD release...")
+
+        base_url = "https://api.github.com/repos"
+        response = requests.get(f"{base_url}/xpack-dev-tools/openocd-xpack/releases/latest")
+
+        details = response.content.decode('utf-8')
+        content = json.loads(details)
+
+        archive_file, hash_file = self.get_github_assets(content["assets"])
+        computed_hash, provided_hash = self.get_hashes(archive_file, hash_file)
+        if computed_hash != provided_hash:
+            self.status.setText("Hashes do not match - corrupted download!")
+            return
+
+        self.unpack_archive(archive_file)
+        add_openocd_to_system_path(self.status)
+        os.remove(archive_file)
+        os.remove(hash_file)
+
+    def get_hashes(self, archive_file, hash_file):
+        self.status.setText("Computing hashes OpenOCD...")
+        with open(archive_file, "rb") as fd:
+            hasher = hashlib.sha256()
+            hasher.update(fd.read())
+            computed_hash = hasher.hexdigest()
+        with open(hash_file, "r") as fd:
+            provided_hash= fd.read().split(" ")[0]   # format: "<hash> <filename>"
+        return computed_hash, provided_hash
+
+    def unpack_archive(self, archive):
+        """
+        Unpack the archive and shift files so that the files can always be found
+        under 'openocd/' (i.e. without a version number, which is how they are
+        currently packed).
+        """
+        self.status.setText("Unpacking OpenOCD...")
+        tmpdir_name = "openocd_tmp"
+        shutil.unpack_archive(archive, extract_dir=tmpdir_name)
+        tmpdir_contents = os.listdir(tmpdir_name)
+
+        if len(tmpdir_contents) == 1:
+            shutil.move(os.path.join(tmpdir_name, tmpdir_contents[0]), "openocd")
+            os.rmdir(tmpdir_name)
+        else:
+            shutil.move(tmpdir_name, "openocd")
+
+    def get_github_assets(self, assets: List[str]):
+        plat = {
+            "Windows": "win32",
+            "Linux": "linux",
+            "MacOS": "darwin",
+        }.get(platform.system(), "")
+        arch = {
+            "x86_64": "x64",
+            "i386": "ia32"
+        }.get(platform.machine(), "")
+
+        if not plat or not arch:
+            self.status.setText("Unable to determine appropriate OpenOCD download.")
+            return
+
+        download_urls = [f["browser_download_url"] for f in assets if plat in f["name"] and arch in f["name"]]
+        filenames = [f["name"] for f in assets if plat in f["name"] and arch in f["name"]]
+        assert len(download_urls) == 2
+
+        self.status.setText("Downloading OpenOCD from GitHub...")
+        if not os.path.exists(filenames[0]) and not os.path.exists(filenames[1]):
+            wget.download(download_urls[0])
+            wget.download(download_urls[1])
+
+        filenames.sort()
+        return filenames
 
 
 # Info screen class and UI

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -301,6 +301,7 @@ class ConfDialog(QDialog):
             "MacOS": "darwin",
         }.get(platform.system(), "")
         arch = {
+            "AMD64": "x64",
             "x86_64": "x64",
             "i386": "ia32"
         }.get(platform.machine(), "")

--- a/PinetimeFlasher.pyw
+++ b/PinetimeFlasher.pyw
@@ -15,10 +15,9 @@ import pickle
 from typing import List
 
 
-def add_openocd_to_system_path(status_notice: QLabel):
+def add_openocd_to_system_path():
     openocd_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'openocd', 'bin')
     os.environ["PATH"] = os.environ["PATH"] + os.pathsep + openocd_path
-    status_notice.setText("OpenOCD downloaded and added to system path.")
 
 
 # Returns percentage progress value in response to key phrases from OpenOCD
@@ -98,8 +97,6 @@ class ptflasher(QMainWindow):
         w.setLayout(layout)
 
         self.setCentralWidget(w)
-        if os.path.exists('openocd'):
-            add_openocd_to_system_path(self.status)
 
     def update_control_statuses(self):
         def enable_buttons(enable: bool, reason: str):
@@ -212,8 +209,6 @@ class ConfDialog(QDialog):
         self.status = QLabel("")
 
         conflayout = QVBoxLayout()
-        confbuttonrow = QHBoxLayout()
-
         conflayout.addWidget(self.addrinfo)
         conflayout.addWidget(self.addrbox)
         conflayout.addWidget(self.ifaceinfo)
@@ -221,7 +216,6 @@ class ConfDialog(QDialog):
         conflayout.addWidget(self.savebtn)
         conflayout.addWidget(self.openocd_btn)
         conflayout.addWidget(self.status)
-
         self.setLayout(conflayout)
 
         address, interface = read_config_file(self.status)
@@ -269,7 +263,7 @@ class ConfDialog(QDialog):
             return
 
         self.unpack_archive(archive_file)
-        add_openocd_to_system_path(self.status)
+        self.status.setText("OpenOCD successfully downloaded.")
         os.remove(archive_file)
         os.remove(hash_file)
 
@@ -376,6 +370,8 @@ if __name__ == "__main__":
     qp.setColor(QPalette.Window, Qt.gray)
     qp.setColor(QPalette.Button, Qt.gray)
     app.setPalette(qp)
+
+    add_openocd_to_system_path()
 
     win = ptflasher()
     win.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 PyQt5==5.15.4
+PyQt5-stubs==5.15.2
 PyQt5-Qt5==5.15.2
 PyQt5-sip==12.8.1
+wget
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt5==5.15.4
-PyQt5-stubs==5.15.2
+PyQt5-stubs==5.15.2.0
 PyQt5-Qt5==5.15.2
 PyQt5-sip==12.8.1
 wget


### PR DESCRIPTION
There is now a button in the configure dialog, cunningly named "Download OpenOCD", which, shockingly, downloads OpenOCD, unpacks it to a directory named `openocd/` adjacent to the script itself. It then adds it to the system path (and this is picked up by the validation of the main dialog).

Apologies for the size of the change, the stuff relating to downloading from GitHub is pretty self-contained though.

This would resolve issue #2 